### PR TITLE
Prevent preprocessor warning in newer Defold

### DIFF
--- a/mime/src/mime.c
+++ b/mime/src/mime.c
@@ -1,6 +1,8 @@
 #define LIB_NAME "Mime"
 #define MODULE_NAME "mime"
+#ifndef DLIB_LOG_DOMAIN
 #define DLIB_LOG_DOMAIN LIB_NAME
+#endif
 
 
 /*=========================================================================*\


### PR DESCRIPTION
Prevents:

```
/mime/src/mime.c
	Line 3: 'DLIB_LOG_DOMAIN' macro redefined [-Wmacro-redefined]
#define DLIB_LOG_DOMAIN LIB_NAME
        ^
```